### PR TITLE
bugfix: delete old iam key with session keys

### DIFF
--- a/internal/redyl/io/io.go
+++ b/internal/redyl/io/io.go
@@ -109,7 +109,7 @@ func (a AccessKeyRotator) rotate(profile string) string {
 	home := a.getHomeDirectory()
 	profileOriginal := profile + "_original"
 	key := getCurrentIamKey(profileOriginal, home)
-	a.deleteIamKey(profileOriginal, key)
+	a.deleteIamKey(profile, key)
 	params := a.createIamKey(profile)
 	location := updateCredentials(profileOriginal, params, home)
 


### PR DESCRIPTION
mistakenly, we were formerly using the "original" (long-lived) keys to delete old keys - we should use the session keys for this instead.